### PR TITLE
Fixed both reported bugs involving the file explorer

### DIFF
--- a/imagelab/ImageLab.java
+++ b/imagelab/ImageLab.java
@@ -303,8 +303,6 @@ public class ImageLab {
                         System.out.print("please select an image file.");
                     }
                 }
-                else
-                    System.out.print("please select an image.");
             } //actionPerformed
         };
     } // makeOpenListener

--- a/imagelab/ImageLab.java
+++ b/imagelab/ImageLab.java
@@ -288,13 +288,23 @@ public class ImageLab {
                 fd = new FileDialog(frame, "Pick an image", FileDialog.LOAD);
                 fd.setVisible(true);
                 String theFile = fd.getFile();
-                String theDir = fd.getDirectory();
-                //System.out.println("The file's name is " + theDir + theFile);
-                improvider = new ImgProvider(theDir + theFile);
-                improvider.setLab(theLab);
-                improvider.showImage(theDir + theFile);
-                images.add(improvider);
-                impro = improvider; //current image provider is set
+                if (theFile != null) {
+                    String extension = theFile.substring(theFile.lastIndexOf(".") + 1);
+                    if(extension.equals("jpg") || extension.equals("gif")) {
+                        String theDir = fd.getDirectory();
+                        //System.out.println("The file's name is " + theDir + theFile);
+                        improvider = new ImgProvider(theDir + theFile);
+                        improvider.setLab(theLab);
+                        improvider.showImage(theDir + theFile);
+                        images.add(improvider);
+                        impro = improvider; //current image provider is set
+                    }
+                    else {
+                        System.out.print("please select an image file.");
+                    }
+                }
+                else
+                    System.out.print("please select an image.");
             } //actionPerformed
         };
     } // makeOpenListener


### PR DESCRIPTION
Added checks to make sure the file explorer is returning value outputs. One check ensures it is an image file, the other makes sure a null is not returned which happens when the explorer is closed without selecting a file.

Both checks might be able to be condensed down to one check and we might be able to add a GUI popup instead of just a System.out on check failure.